### PR TITLE
fix git diff in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,5 +63,6 @@ jobs:
           set -euxo pipefail
           npm ci
           npm run build
-          git diff --ignore-space-change --stat --exit-code HEAD
+          # exclude dist/index.js.map (different on Windows)
+          git diff --stat --exit-code HEAD -- ':!dist/index.js.map'
         shell: bash


### PR DESCRIPTION
Seems like --ignore-space-change breaks --exit-code, so we just exclude the .map file now