### PR TITLE
Upgrade action to use node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Verify D compiler (dub)
         run: dub run --single -q .github/hello.d
 
-      - name: Install Node.js 12.x
+      - name: Install Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: 16
 
       - name: Ensure `dist/index.js` is up to date
         run: |

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     default: ${{ github.token }}
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/