### PR TITLE
Get master CI green: Disable dub-latest and bump minimum DMD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ jobs:
             ldc-latest,
             ldc-beta,
             ldc-master,
-            dmd-2.097.0,
+            # Need fix for https://issues.dlang.org/show_bug.cgi?id=22942 for macOS
+            dmd-2.099.1,
             dmd-latest,
             dmd-beta,
             dmd-master,
@@ -74,7 +75,7 @@ jobs:
       matrix:
         os:  [ ubuntu-latest, windows-latest, macOS-latest ]
         dc:  [ ldc-latest, dmd-latest ]
-        dub: [ 1.19.0, 1.23.0, 1.24.0, latest ]
+        dub: [ 1.19.0, 1.23.0, 1.24.0 ]
         exclude:
           # Excluded because those are actually Linux executables
           - { os: windows-latest, dub: 1.19.0 }


### PR DESCRIPTION
We need to bump the minimum DMD to get a fix for newer MacOS images, and we disable the dub latest test as releases are not currently being uploaded, and while this is being worked on, it should not block this repository.