### PR TITLE
README.md: Add v2 changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: dub -q test
 ```
-The above example test 11 possible combinations: the latest `dmd` and latest `ldc` on all three platforms,
+The above example tests 11 possible combinations: the latest `dmd` and latest `ldc` on all three platforms,
 `ldc-1.17.0` on all three platforms, and `dmd-2.085.0` on `ubuntu-latest` and `windows-latest`.
 
 Gdc usage:
@@ -85,7 +85,9 @@ jobs:
 ```
 
 
-Simply add the setup-dlang action to your GitHub Actions workflow to automatically download and install a D compiler and package manager bundled with the compiler or separately downloaded. The action will automatically add the D binaries to the `PATH` environment variable and set the `DC` environment variable to the selected compiler executable name.
+Simply add the setup-dlang action to your GitHub Actions workflow to automatically download and install a D compiler and package manager bundled with the compiler or separately downloaded. The action will automatically add the D binaries to the `PATH` environment variable and set the `DC` environment variable to the selected compiler.
+Note, this behavior has been slightly adjusted in v2.
+For more details check the changes below.
 
 ## Input to this action
 
@@ -224,3 +226,16 @@ If the `dub` parameter is provided to the action, that version will be the one i
 Note that DUB versions prior to v1.13.0 (DMD version v2.084.0, released 2019-01-02) do not support HTTP2,
 meaning they will not work for fetching packages.
 Additionally, some tags of dub (`v1.29.1` - `v1.36.0`) don't have releases so you won't be able to install them (https://github.com/dlang-community/setup-dlang/issues/64)
+
+## Changes from v1
+
+The most important change is the `$DC` environment variable becoming an absolute path instead of only the filename.
+Depending on how it is used in scripts care must be taken to properly quote it especially on windows to avoid the `\` character being lost.
+
+DMD versions prior to `dmd-2.072` will no longer install dub automatically.
+If you need dub with these versions just specify it as an argument to the action.
+
+When specifying `dmd-beta` the action may install `dmd-latest` if it determines that it has a more recent version.
+Example, if the latest DMD beta is `2.098.1_rc1` and the latest DMD release is `2.099.0` then `dmd-beta` will now resolve to `2.099.0` instead of `2.098.1_rc1`.
+
+The minimum available version of dmd has been raised to `2.065.0`.


### PR DESCRIPTION
I've tried to document all the meaningful changes from v2 to v1. I have skipped some as I am uncertain of their merit:

1. On windows the dub binary that comes with the compiler is no longer deleted when the user specifies the `dub:` parameter. I don't know why the old code was doing it but CI does pass without it. The relevant snippet of the old code: https://github.com/dlang-community/setup-dlang/blob/2979e3ea011f6a234cd3a47dcbeb60f451c9635f/src/main.ts#L50-L58

2. On arm64 macos, with ldc older then 1.30.0_beta1 (the first universal release) the only library directory that is added to `LD_LIBRARY_PATH` is `lib`, not `lib-x86_64` or `lib-arm64`. The old code is: https://github.com/dlang-community/setup-dlang/blob/2979e3ea011f6a234cd3a47dcbeb60f451c9635f/src/compiler.ts#L289-L313 The difference is that ldc2 on x86_64 will no longer have `lib-arm64` added to `LD_LIBRARY_PATH`. Now I think that this is a mistake and that directory should be added but I want to confirm this first. ldc2 is configured to use that directory but since the actions says that it will be added to `LD_LIBRARY_PATH` I want to be certain that this is the right thing to do.